### PR TITLE
Added auto-update section to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,21 @@ cd ~/moonraker-mattaos
 
 _Note: if you have issues running the `uninstall.sh` file run `chmod +x ./uninstall.sh`._
 </details>
+<details>
+  <summary><b>Enable automatic updates</b></summary>
+    <br/>
+To enable automatic updates of the plugin, simply add this section at the end of your moonraker.conf
+
+```yaml
+[update_manager mattaos]
+type: git_repo
+path: ~/moonraker-mattaos
+origin: https://github.com/Matta-Labs/moonraker-mattaos.git
+managed_services: moonraker-mattaos
+primary_branch: main
+install_script: install.sh
+```
+</details>
 
 
 ## 📸 Nozzle Cameras


### PR DESCRIPTION
I have noticed that there is no auto-update section on the readme even if this is a moonraker feature that we can take advantage of, just added it on the setup section so it is available for everyone to copy/paste.